### PR TITLE
Rename as it's custom module.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "soap",
+  "name": "busbud-soap",
   "version": "0.4.2",
   "description": "A minimal node SOAP client",
   "engines": {


### PR DESCRIPTION
New providers may need (and some do) the latest version of Node Soap in order to work. Rename this module for older providers that require it.

Note: Will update old providers before merging request.